### PR TITLE
Import path problem in using ESM feature typescript@next

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -6,7 +6,7 @@ import { Alternative2 } from 'fp-ts/lib/Alternative'
 import { Applicative2 } from 'fp-ts/lib/Applicative'
 import * as A from 'fp-ts/lib/Array'
 import { Chain2 } from 'fp-ts/lib/Chain'
-import { tailRec, ChainRec2 } from 'fp-ts/ChainRec'
+import { tailRec, ChainRec2 } from 'fp-ts/lib/ChainRec'
 import * as E from 'fp-ts/lib/Either'
 import { Functor2 } from 'fp-ts/lib/Functor'
 import { Monad2 } from 'fp-ts/lib/Monad'
@@ -643,7 +643,7 @@ export const URI = 'Parser'
  */
 export type URI = typeof URI
 
-declare module 'fp-ts/lib/HKT' {
+declare module 'fp-ts/HKT' {
   interface URItoKind2<E, A> {
     Parser: Parser<E, A>
   }

--- a/src/string.ts
+++ b/src/string.ts
@@ -3,7 +3,7 @@
  */
 import { Foldable, Foldable1 } from 'fp-ts/lib/Foldable'
 import { Functor, Functor1 } from 'fp-ts/lib/Functor'
-import { HKT, Kind, URIS } from 'fp-ts/lib/HKT'
+import { HKT, Kind, URIS } from 'fp-ts/HKT'
 import * as E from 'fp-ts/Either'
 import * as M from 'fp-ts/lib/Monoid'
 import * as O from 'fp-ts/lib/Option'


### PR DESCRIPTION
I am trying to build ECMAScript modules (ESM) that is supported by TypeScript nightly build.

https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/

`tsc` fail in *.mts (new source file extension for ESM) that imports `parser-ts` module.

This issue seems to be fixable by [change the import path. ](https://github.com/oocytanb/parser-ts/commit/3fc4e2954f89c0285dc8a7704763a37103ab6315)

- 'fp-ts/ChainRec' to 'fp-ts/lib/ChainRec'
- 'fp-ts/lib/HKT' to 'fp-ts/HKT'

## Error log

```
node_modules/parser-ts/lib/Parser.d.ts(7,27): error TS2307: Cannot find module 'fp-ts/ChainRec' or its corresponding type declarations.
node_modules/parser-ts/lib/Parser.d.ts(410,16): error TS2665: Invalid module name in augmentation. Module 'fp-ts/lib/HKT' resolves to an untyped module at 'node_modules/fp-ts/lib/HKT/index.js', which cannot be augmented.
node_modules/parser-ts/lib/Parser.d.ts(429,40): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(434,48): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(439,36): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(449,32): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(454,48): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(459,37): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/Parser.d.ts(459,57): error TS2344: Type '"Parser"' does not satisfy the constraint 'keyof URItoKind2<any, any>'.
node_modules/parser-ts/lib/string.d.ts(6,33): error TS7016: Could not find a declaration file for module 'fp-ts/lib/HKT'. 'node_modules/fp-ts/lib/HKT/index.js' implicitly has an 'any' type.
  If the 'fp-ts' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module 'fp-ts/lib/HKT';`
```

## Source codes

main.mts

```
import { parser as P, string as S } from 'parser-ts';
console.log(P, S);
```

tsconfig.json

```
{
  "compilerOptions": {
    "strict": true,
    "module": "nodenext",
  }
}
```

package.json

```
{
  "name": "test_esm",
  "type": "module",
  "devDependencies": {
    "typescript": "^4.6.0-dev.20211113"
  },
  "dependencies": {
    "fp-ts": "^2.11.5",
    "parser-ts": "^0.6.16"
  },
  "scripts": {
    "build": "tsc"
  }
}
```

Thank you.